### PR TITLE
accept a custom console parameter in runLocalCode

### DIFF
--- a/lib/Sandbox.js
+++ b/lib/Sandbox.js
@@ -187,10 +187,10 @@ class Sandbox {
     });
   }
 
-  runLocalCode(filename, req) {
+  runLocalCode(filename, req, { console } = {}) {
     return new Promise((accept, reject) => {
       const code = fs.readFileSync(filename, 'utf8');
-      const options = { prefix: filename };
+      const options = { prefix: filename, console };
       const invalid = this.testSyntaxError(filename, code, options);
 
       if (invalid) {

--- a/test/Sandbox.test.js
+++ b/test/Sandbox.test.js
@@ -382,5 +382,38 @@ describe('Sandbox', () => {
           }).catch(err => done(err));
       });
     });
+
+    describe('options', () => {
+      it('should allow pass a console instance', (done) => {
+        const filename = './test/support/valid.js';
+        const req = {};
+
+        const mockedConsole = {
+          error: () => {},
+          log: () => {},
+          info: () => {},
+          warn: () => {},
+        };
+
+        const testSyntaxErrorCalls = [];
+        testSandbox.testSyntaxError = (...args) => {
+          testSyntaxErrorCalls.push(args);
+        };
+
+        const runScriptCalls = [];
+        testSandbox.runScript = (...args) => {
+          runScriptCalls.push(args);
+          return Promise.resolve();
+        };
+
+        testSandbox
+          .runLocalCode(filename, req, { console: mockedConsole })
+          .then(() => {
+            expect(testSyntaxErrorCalls[0][2].console).to.eql(mockedConsole);
+            expect(runScriptCalls[0][2].console).to.eql(mockedConsole);
+            done();
+          }).catch(err => done(err));
+      });
+    });
   });
 });


### PR DESCRIPTION
Would be nice to be able to mock the console, specially when running tests, to have a cleaner output. Could be used to make assertions also